### PR TITLE
feat: Enhanced LLM error handling with async mode, caching, rate limiting and route param support

### DIFF
--- a/.cursor/plans/radar_portal_frontend_eb69ecbf.plan.md
+++ b/.cursor/plans/radar_portal_frontend_eb69ecbf.plan.md
@@ -361,22 +361,22 @@ todos:
     status: pending
   - id: settings
     content: '--- Page: Settings (/settings) ---'
-    status: pending
+    status: completed
   - id: settings-route
     content: 'Settings: route; useApiKeys(), useTeam() hooks'
-    status: pending
+    status: completed
   - id: settings-api-keys
     content: 'Settings: API keys section — list keys (name, prefix, created, last used), create key (show full key once), revoke with confirmation; keys are account-level, one key works across all te.js projects'
-    status: pending
+    status: completed
   - id: settings-team
     content: 'Settings: team section — invite member by email, role selector (admin/member/viewer), remove member'
-    status: pending
+    status: completed
   - id: settings-account
     content: 'Settings: account section — display name, email, password change'
-    status: pending
+    status: completed
   - id: settings-states
     content: 'Settings: Skeleton, ErrorPanel; destructive actions require confirmation dialog; Sonner toasts'
-    status: pending
+    status: completed
   - id: billing
     content: '--- Page: Billing (/settings/billing) ---'
     status: pending

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,15 +110,22 @@ These options configure the `tejas generate:docs` CLI command and the auto-docum
 
 ### Error handling (LLM-inferred errors)
 
-When [LLM-inferred error codes and messages](./error-handling.md#llm-inferred-errors) are enabled, the **`errors.llm`** block configures the LLM used for inferring status code and message when you call `ammo.throw()` without explicit code or message. Unset values fall back to `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL`. You can also enable (and optionally set connection options) by calling **`app.withLLMErrors(config?)`** before `takeoff()` — e.g. `app.withLLMErrors()` to use env/config for baseURL, apiKey, model, or `app.withLLMErrors({ baseURL, apiKey, model, messageType })` to override in code.
+When [LLM-inferred error codes and messages](./error-handling.md#llm-inferred-errors) are enabled, the **`errors.llm`** block configures the LLM used for inferring status code and message when you call `ammo.throw()` without explicit code or message. Unset values fall back to `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL`. You can also enable (and optionally set connection options) by calling **`app.withLLMErrors(config?)`** before `takeoff()` — e.g. `app.withLLMErrors()` to use env/config for baseURL, apiKey, model, or `app.withLLMErrors({ baseURL, apiKey, model, messageType, mode, ... })` to override in code.
 
-| Config Key               | Env Variable                                     | Type                         | Default                       | Description                                                                                                                                  |
-| ------------------------ | ------------------------------------------------ | ---------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `errors.llm.enabled`     | `ERRORS_LLM_ENABLED` or `LLM_*` (for connection) | boolean                      | `false`                       | Enable LLM-inferred error code and message for `ammo.throw()`                                                                                |
-| `errors.llm.baseURL`     | `ERRORS_LLM_BASE_URL` or `LLM_BASE_URL`          | string                       | `"https://api.openai.com/v1"` | LLM provider endpoint for error inference                                                                                                    |
-| `errors.llm.apiKey`      | `ERRORS_LLM_API_KEY` or `LLM_API_KEY`            | string                       | —                             | LLM provider API key for error inference                                                                                                     |
-| `errors.llm.model`       | `ERRORS_LLM_MODEL` or `LLM_MODEL`                | string                       | `"gpt-4o-mini"`               | LLM model for error inference                                                                                                                |
-| `errors.llm.messageType` | `ERRORS_LLM_MESSAGE_TYPE` or `LLM_MESSAGE_TYPE`  | `"endUser"` \| `"developer"` | `"endUser"`                   | Default tone for LLM-generated message: `endUser` (safe for clients) or `developer` (technical detail). Overridable per `ammo.throw()` call. |
+| Config Key               | Env Variable                                    | Type                               | Default              | Description                                                                                                                                                                                                          |
+| ------------------------ | ----------------------------------------------- | ---------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `errors.llm.enabled`     | `ERRORS_LLM_ENABLED`                            | boolean                            | `false`              | Enable LLM-inferred error code and message for `ammo.throw()` and framework-caught errors.                                                                                                                           |
+| `errors.llm.baseURL`     | `ERRORS_LLM_BASE_URL` or `LLM_BASE_URL`         | string                             | —                    | LLM provider endpoint (e.g. `https://api.openai.com/v1`). Required when enabled.                                                                                                                                     |
+| `errors.llm.apiKey`      | `ERRORS_LLM_API_KEY` or `LLM_API_KEY`           | string                             | —                    | LLM provider API key. Required when enabled.                                                                                                                                                                         |
+| `errors.llm.model`       | `ERRORS_LLM_MODEL` or `LLM_MODEL`               | string                             | —                    | LLM model name (e.g. `gpt-4o-mini`). Required when enabled.                                                                                                                                                          |
+| `errors.llm.messageType` | `ERRORS_LLM_MESSAGE_TYPE` or `LLM_MESSAGE_TYPE` | `"endUser"` \| `"developer"`       | `"endUser"`          | Default tone for LLM-generated messages. `endUser` is safe for clients; `developer` includes technical detail. Overridable per `ammo.throw()` call.                                                                  |
+| `errors.llm.mode`        | `ERRORS_LLM_MODE` or `LLM_MODE`                 | `"sync"` \| `"async"`              | `"sync"`             | `sync` blocks the HTTP response until the LLM returns. `async` sends an immediate 500 and runs the LLM in the background, dispatching the result to the configured channel.                                          |
+| `errors.llm.timeout`     | `ERRORS_LLM_TIMEOUT` or `LLM_TIMEOUT`           | number (ms)                        | `10000`              | Maximum time in milliseconds to wait for an LLM response before aborting with a timeout error.                                                                                                                       |
+| `errors.llm.channel`     | `ERRORS_LLM_CHANNEL` or `LLM_CHANNEL`           | `"console"` \| `"log"` \| `"both"` | `"console"`          | Output channel for async mode results. `console` pretty-prints to the terminal; `log` appends JSONL to the log file; `both` does both. Only applies when `mode` is `async`.                                          |
+| `errors.llm.logFile`     | `ERRORS_LLM_LOG_FILE`                           | string (path)                      | `"./errors.llm.log"` | Path for the JSONL log file used by the `log` and `both` channels.                                                                                                                                                   |
+| `errors.llm.rateLimit`   | `ERRORS_LLM_RATE_LIMIT` or `LLM_RATE_LIMIT`     | number                             | `10`                 | Maximum number of LLM calls allowed per minute across all requests. When exceeded, a generic 500 is returned (sync) or dispatched with a `rateLimited` flag (async). Cached results do not count against this limit. |
+| `errors.llm.cache`       | `ERRORS_LLM_CACHE`                              | boolean                            | `true`               | Cache LLM results by throw site (file + line) and error message. Repeated errors at the same location reuse the cached result without making another LLM call.                                                       |
+| `errors.llm.cacheTTL`    | `ERRORS_LLM_CACHE_TTL`                          | number (ms)                        | `3600000`            | How long cached results are reused (default 1 hour). After expiry the same error will trigger a fresh LLM call.                                                                                                      |
 
 When enabled, the same behaviour applies whether you call `ammo.throw()` or the framework calls it when it catches an error — one mechanism, no separate config.
 
@@ -162,7 +169,14 @@ Create a `tejas.config.json` in your project root:
       "enabled": true,
       "baseURL": "https://api.openai.com/v1",
       "model": "gpt-4o-mini",
-      "messageType": "endUser"
+      "messageType": "endUser",
+      "mode": "async",
+      "timeout": 10000,
+      "channel": "both",
+      "logFile": "./errors.llm.log",
+      "rateLimit": 10,
+      "cache": true,
+      "cacheTTL": 3600000
     }
   }
 }

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -15,8 +15,8 @@ Tejas wraps all middleware and route handlers with built-in error catching. Any 
 ```javascript
 // ✅ No try-catch needed — Tejas handles errors automatically
 target.register('/users/:id', async (ammo) => {
-  const user = await database.findUser(ammo.payload.id);  // If this throws, Tejas catches it
-  const posts = await database.getUserPosts(user.id);      // Same here
+  const user = await database.findUser(ammo.payload.id); // If this throws, Tejas catches it
+  const posts = await database.getUserPosts(user.id); // Same here
   ammo.fire({ user, posts });
 });
 ```
@@ -30,8 +30,8 @@ app.get('/users/:id', async (req, res) => {
     const user = await database.findUser(req.params.id);
     res.json(user);
   } catch (error) {
-    console.error(error);           // 1. log
-    res.status(500).json({ error: 'Internal Server Error' });  // 2. send response
+    console.error(error); // 1. log
+    res.status(500).json({ error: 'Internal Server Error' }); // 2. send response
   }
 });
 ```
@@ -47,8 +47,8 @@ To see caught exceptions in your logs, enable exception logging:
 ```javascript
 const app = new Tejas({
   log: {
-    exceptions: true  // Log all caught exceptions
-  }
+    exceptions: true, // Log all caught exceptions
+  },
 });
 ```
 
@@ -89,6 +89,87 @@ ammo.throw({ messageType: 'developer' });
 ammo.throw(caughtErr, { useLlm: false });
 ```
 
+### Async mode
+
+By default (`errors.llm.mode: 'sync'`), `ammo.throw()` blocks the HTTP response until the LLM returns. This adds LLM latency (typically 1–3 seconds) to every error response.
+
+Set `errors.llm.mode` to `'async'` to respond immediately with a generic `500 Internal Server Error` and run the LLM inference in the background. The result is dispatched to the configured **channel** once ready — the client never waits.
+
+```bash
+# .env
+ERRORS_LLM_MODE=async
+ERRORS_LLM_CHANNEL=both   # console + log file
+```
+
+```javascript
+// tejas.config.json
+{
+  "errors": {
+    "llm": {
+      "enabled": true,
+      "mode": "async",
+      "channel": "both"
+    }
+  }
+}
+```
+
+In async mode:
+
+- The HTTP response is always `500 Internal Server Error` regardless of what the LLM would infer. The LLM-inferred status and message are only visible in the channel.
+- Developer insight (`devInsight`) is **always** included in the channel output, even in production — it never reaches the HTTP response.
+- If the LLM call fails or times out in the background, it is silently swallowed. The HTTP response has already been sent.
+
+### Output channels (async mode)
+
+When `mode` is `async`, the LLM result is sent to the configured channel after the response. Set `errors.llm.channel`:
+
+| Channel               | Output                                                                                                                                                                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"console"` (default) | Pretty-printed colored block in the terminal: timestamp, method+path, inferred status, message, dev insight. Shows `[CACHED]` or `[RATE LIMITED]` flags.                                                                        |
+| `"log"`               | Appends a JSON line to `errors.llm.logFile` (default `./errors.llm.log`). Each entry contains all fields: timestamp, method, path, statusCode, message, devInsight, original error, code context snippets, cached, rateLimited. |
+| `"both"`              | Both console and log file.                                                                                                                                                                                                      |
+
+The log file uses **JSONL format** (one JSON object per line), so it can be read by log analysis tools or Radar.
+
+```bash
+ERRORS_LLM_CHANNEL=log
+ERRORS_LLM_LOG_FILE=./logs/llm-errors.log
+```
+
+### Rate limiting
+
+Set `errors.llm.rateLimit` (default `10`) to cap the number of LLM calls per minute across all requests. This prevents a burst of errors from exhausting your API quota.
+
+```bash
+ERRORS_LLM_RATE_LIMIT=20
+```
+
+When the rate limit is exceeded:
+
+- **Sync mode**: responds immediately with `500 Internal Server Error` (no LLM call).
+- **Async mode**: the channel still receives a dispatch with `rateLimited: true` so the error occurrence is recorded even though LLM enhancement was skipped.
+
+Cached results do **not** count against the rate limit.
+
+### Error caching
+
+By default (`errors.llm.cache: true`), Tejas caches LLM results by throw site and error message. If the same error is thrown at the same file and line, the cached result is reused without making another LLM call.
+
+```bash
+ERRORS_LLM_CACHE=true
+ERRORS_LLM_CACHE_TTL=3600000   # 1 hour (default)
+```
+
+The cache key is: `file:line:errorMessage`. After the TTL expires, the next occurrence triggers a fresh LLM call.
+
+To effectively **only enhance new errors**, keep caching enabled with a long TTL. To re-evaluate errors more frequently, reduce the TTL.
+
+```javascript
+// Only enhance errors once per 24 hours
+app.withLLMErrors({ cache: true, cacheTTL: 86400000 });
+```
+
 ---
 
 ## TejError Class
@@ -113,6 +194,7 @@ throw new TejError(404, 'Resource not found');
 ```
 
 **Response:**
+
 ```
 HTTP/1.1 404 Not Found
 Content-Type: text/plain
@@ -148,7 +230,7 @@ ammo.throw(new TejError(400, 'Bad request'));
 // When errors.llm.enabled: LLM infers code and message from context
 ammo.throw(new Error('Something went wrong'));
 ammo.throw('Validation failed');
-ammo.throw();  // context still used when available
+ammo.throw(); // context still used when available
 ```
 
 See [Ammo — throw()](./ammo.md#throw--send-error-response) for all signatures and the LLM-inferred row.
@@ -160,13 +242,13 @@ See [Ammo — throw()](./ammo.md#throw--send-error-response) for all signatures 
 ```javascript
 target.register('/users/:id', async (ammo) => {
   const { id } = ammo.payload;
-  
+
   const user = await findUser(id);
-  
+
   if (!user) {
     throw new TejError(404, 'User not found');
   }
-  
+
   ammo.fire(user);
 });
 ```
@@ -194,8 +276,8 @@ Errors are automatically caught by Tejas's handler. Enable logging:
 ```javascript
 const app = new Tejas({
   log: {
-    exceptions: true // Log all exceptions
-  }
+    exceptions: true, // Log all exceptions
+  },
 });
 ```
 
@@ -207,18 +289,18 @@ Create middleware to customize error handling:
 // middleware/error-handler.js
 export const errorHandler = (ammo, next) => {
   const originalThrow = ammo.throw.bind(ammo);
-  
+
   ammo.throw = (...args) => {
     // Log errors
     console.error('Error:', args);
-    
+
     // Send to error tracking service
     errorTracker.capture(args[0]);
-    
+
     // Call original throw
     originalThrow(...args);
   };
-  
+
   next();
 };
 
@@ -234,12 +316,12 @@ For APIs, return structured error objects:
 // middleware/api-errors.js
 export const apiErrorHandler = (ammo, next) => {
   const originalThrow = ammo.throw.bind(ammo);
-  
+
   ammo.throw = (statusOrError, message) => {
     let status = 500;
     let errorMessage = 'Internal Server Error';
     let errorCode = 'INTERNAL_ERROR';
-    
+
     if (typeof statusOrError === 'number') {
       status = statusOrError;
       errorMessage = message || getDefaultMessage(status);
@@ -249,16 +331,16 @@ export const apiErrorHandler = (ammo, next) => {
       errorMessage = statusOrError.message;
       errorCode = getErrorCode(status);
     }
-    
+
     ammo.fire(status, {
       error: {
         code: errorCode,
         message: errorMessage,
-        status
-      }
+        status,
+      },
     });
   };
-  
+
   next();
 };
 
@@ -270,7 +352,7 @@ function getDefaultMessage(status) {
     404: 'Not Found',
     405: 'Method Not Allowed',
     429: 'Too Many Requests',
-    500: 'Internal Server Error'
+    500: 'Internal Server Error',
   };
   return messages[status] || 'Unknown Error';
 }
@@ -283,13 +365,14 @@ function getErrorCode(status) {
     404: 'NOT_FOUND',
     405: 'METHOD_NOT_ALLOWED',
     429: 'RATE_LIMITED',
-    500: 'INTERNAL_ERROR'
+    500: 'INTERNAL_ERROR',
   };
   return codes[status] || 'UNKNOWN_ERROR';
 }
 ```
 
 **Response:**
+
 ```json
 {
   "error": {
@@ -307,10 +390,10 @@ For input validation, return detailed errors:
 ```javascript
 target.register('/users', (ammo) => {
   if (!ammo.POST) return ammo.notAllowed();
-  
+
   const { name, email, age } = ammo.payload;
   const errors = [];
-  
+
   if (!name) errors.push({ field: 'name', message: 'Name is required' });
   if (!email) errors.push({ field: 'email', message: 'Email is required' });
   if (email && !isValidEmail(email)) {
@@ -319,17 +402,17 @@ target.register('/users', (ammo) => {
   if (age && (isNaN(age) || age < 0)) {
     errors.push({ field: 'age', message: 'Age must be a positive number' });
   }
-  
+
   if (errors.length > 0) {
     return ammo.fire(400, {
       error: {
         code: 'VALIDATION_ERROR',
         message: 'Validation failed',
-        details: errors
-      }
+        details: errors,
+      },
     });
   }
-  
+
   // Process valid data...
 });
 ```
@@ -380,16 +463,17 @@ While Tejas catches all errors automatically, you may want try-catch for:
 
 `BodyParserError` is a subclass of `TejError` thrown automatically during request body parsing. You do not need to handle these yourself — they are caught by the framework and converted to appropriate HTTP responses.
 
-| Status | Condition |
-|--------|-----------|
+| Status  | Condition                                                                  |
+| ------- | -------------------------------------------------------------------------- |
 | **400** | Malformed JSON, invalid URL-encoded data, or corrupted multipart form data |
-| **408** | Body parsing timed out (exceeds `body.timeout`, default 30 seconds) |
-| **413** | Request body exceeds `body.max_size` (default 10 MB) |
-| **415** | Unsupported content type (not JSON, URL-encoded, or multipart) |
+| **408** | Body parsing timed out (exceeds `body.timeout`, default 30 seconds)        |
+| **413** | Request body exceeds `body.max_size` (default 10 MB)                       |
+| **415** | Unsupported content type (not JSON, URL-encoded, or multipart)             |
 
 These limits are configured via [Configuration](./configuration.md) (`body.max_size`, `body.timeout`).
 
 Supported content types:
+
 - `application/json`
 - `application/x-www-form-urlencoded`
 - `multipart/form-data`
@@ -410,21 +494,21 @@ Once a response has been sent (`res.headersSent` is true), no further middleware
 
 ## Error Codes Reference
 
-| Status | Name | When to Use |
-|--------|------|-------------|
-| 400 | Bad Request | Invalid input, malformed request |
-| 401 | Unauthorized | Missing or invalid authentication |
-| 403 | Forbidden | Authenticated but not authorized |
-| 404 | Not Found | Resource doesn't exist |
-| 405 | Method Not Allowed | HTTP method not supported |
-| 409 | Conflict | Resource conflict (duplicate) |
-| 413 | Payload Too Large | Request body too large |
-| 422 | Unprocessable Entity | Valid syntax but semantic errors |
-| 429 | Too Many Requests | Rate limit exceeded |
-| 500 | Internal Server Error | Unexpected server errors |
-| 502 | Bad Gateway | Upstream server error |
-| 503 | Service Unavailable | Server temporarily unavailable |
-| 504 | Gateway Timeout | Upstream server timeout |
+| Status | Name                  | When to Use                       |
+| ------ | --------------------- | --------------------------------- |
+| 400    | Bad Request           | Invalid input, malformed request  |
+| 401    | Unauthorized          | Missing or invalid authentication |
+| 403    | Forbidden             | Authenticated but not authorized  |
+| 404    | Not Found             | Resource doesn't exist            |
+| 405    | Method Not Allowed    | HTTP method not supported         |
+| 409    | Conflict              | Resource conflict (duplicate)     |
+| 413    | Payload Too Large     | Request body too large            |
+| 422    | Unprocessable Entity  | Valid syntax but semantic errors  |
+| 429    | Too Many Requests     | Rate limit exceeded               |
+| 500    | Internal Server Error | Unexpected server errors          |
+| 502    | Bad Gateway           | Upstream server error             |
+| 503    | Service Unavailable   | Server temporarily unavailable    |
+| 504    | Gateway Timeout       | Upstream server timeout           |
 
 ## Best Practices
 

--- a/lib/llm/client.js
+++ b/lib/llm/client.js
@@ -6,6 +6,7 @@
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_MODEL = 'gpt-4o-mini';
+const DEFAULT_TIMEOUT = 10000;
 
 /**
  * OpenAI-compatible LLM provider. Exposes only constructor and analyze(prompt).
@@ -15,11 +16,16 @@ class LLMProvider {
     this.baseURL = (options.baseURL ?? DEFAULT_BASE_URL).replace(/\/$/, '');
     this.model = options.model ?? DEFAULT_MODEL;
     this.apiKey = options.apiKey ?? process.env.OPENAI_API_KEY;
+    this.timeout =
+      typeof options.timeout === 'number' && options.timeout > 0
+        ? options.timeout
+        : DEFAULT_TIMEOUT;
     this.options = options;
   }
 
   /**
    * Send a prompt to the LLM and return the raw text response and usage.
+   * Aborts after this.timeout milliseconds and throws a clean error.
    * @param {string} prompt
    * @returns {Promise<{ content: string, usage: { prompt_tokens: number, completion_tokens: number, total_tokens: number } }>}
    */
@@ -34,25 +40,44 @@ class LLMProvider {
       messages: [{ role: 'user', content: prompt }],
     };
 
-    const res = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    let res;
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        throw new Error(`LLM request timed out after ${this.timeout}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!res.ok) {
       const text = await res.text();
-      throw new Error(`LLM request failed (${res.status}): ${text.slice(0, 300)}`);
+      throw new Error(
+        `LLM request failed (${res.status}): ${text.slice(0, 300)}`,
+      );
     }
 
     const data = await res.json();
     const content = data.choices?.[0]?.message?.content ?? '';
-    const text = typeof content === 'string' ? content : JSON.stringify(content);
+    const text =
+      typeof content === 'string' ? content : JSON.stringify(content);
     const rawUsage = data.usage;
     const usage = {
       prompt_tokens: rawUsage?.prompt_tokens ?? 0,
       completion_tokens: rawUsage?.completion_tokens ?? 0,
-      total_tokens: rawUsage?.total_tokens ?? (rawUsage?.prompt_tokens ?? 0) + (rawUsage?.completion_tokens ?? 0),
+      total_tokens:
+        rawUsage?.total_tokens ??
+        (rawUsage?.prompt_tokens ?? 0) + (rawUsage?.completion_tokens ?? 0),
     };
     return { content: text, usage };
   }
@@ -60,7 +85,7 @@ class LLMProvider {
 
 /**
  * Create an LLM provider from config.
- * @param {object} config - { baseURL?, apiKey?, model? }
+ * @param {object} config - { baseURL?, apiKey?, model?, timeout? }
  * @returns {LLMProvider}
  */
 function createProvider(config) {

--- a/server/ammo.js
+++ b/server/ammo.js
@@ -10,6 +10,11 @@ import TejError from './error.js';
 import { getErrorsLlmConfig } from '../utils/errors-llm-config.js';
 import { inferErrorFromContext } from './errors/llm-error-service.js';
 import { captureCodeContext } from './errors/code-context.js';
+import {
+  getChannels,
+  buildPayload,
+  dispatchToChannels,
+} from './errors/channels/index.js';
 
 /**
  * Detect if the value is a throw() options object (per-call overrides).
@@ -367,22 +372,84 @@ class Ammo {
     const llmEligible =
       args.length === 0 ||
       (!isStatusCode(args[0]) && !(args[0] instanceof TejError));
-    let throwOpts = /** @type {{ useLlm?: boolean, messageType?: 'endUser'|'developer' } | null} */ (null);
-    if (llmEligible && args.length > 0 && isThrowOptions(args[args.length - 1])) {
-      throwOpts = /** @type {{ useLlm?: boolean, messageType?: 'endUser'|'developer' } } */ (args.pop());
+    let throwOpts =
+      /** @type {{ useLlm?: boolean, messageType?: 'endUser'|'developer' } | null} */ (
+        null
+      );
+    if (
+      llmEligible &&
+      args.length > 0 &&
+      isThrowOptions(args[args.length - 1])
+    ) {
+      throwOpts =
+        /** @type {{ useLlm?: boolean, messageType?: 'endUser'|'developer' } } */ (
+          args.pop()
+        );
     }
 
-    const useLlm =
-      llmEnabled &&
-      llmEligible &&
-      throwOpts?.useLlm !== false;
+    const useLlm = llmEnabled && llmEligible && throwOpts?.useLlm !== false;
 
     if (useLlm) {
-      // Use stack from thrown error when available (e.g. handler caught and called ammo.throw(err)) so we capture user code; else current call site.
+      // Capture the stack string SYNCHRONOUSLY before any async work or fire() call,
+      // because the call stack unwinds as soon as we await or respond.
       const stack =
         args[0] instanceof Error && args[0].stack
           ? args[0].stack
           : new Error().stack;
+      const originalError =
+        args[0] !== undefined && args[0] !== null ? args[0] : undefined;
+
+      const { mode, channel, logFile } = getErrorsLlmConfig();
+
+      if (mode === 'async') {
+        // Respond immediately with a generic 500, then run LLM in the background.
+        this.fire(500, 'Internal Server Error');
+
+        // Fire-and-forget: capture context, call LLM, dispatch to channel.
+        const method = this.method;
+        const path = this.path;
+        captureCodeContext(stack)
+          .then((codeContext) => {
+            const context = {
+              codeContext,
+              method,
+              path,
+              // Always request devInsight in async mode — it goes to the channel, not the HTTP response.
+              includeDevInsight: true,
+              forceDevInsight: true,
+              ...(throwOpts?.messageType && {
+                messageType: throwOpts.messageType,
+              }),
+            };
+            if (originalError !== undefined) context.error = originalError;
+            return inferErrorFromContext(context).then((result) => ({
+              result,
+              codeContext,
+            }));
+          })
+          .then(({ result, codeContext }) => {
+            const channels = getChannels(channel, logFile);
+            const payload = buildPayload({
+              method,
+              path,
+              originalError,
+              codeContext,
+              statusCode: result.statusCode,
+              message: result.message,
+              devInsight: result.devInsight,
+              cached: result.cached,
+              rateLimited: result.rateLimited,
+            });
+            return dispatchToChannels(channels, payload);
+          })
+          .catch(() => {
+            // Swallow background errors — the HTTP response has already been sent.
+          });
+
+        return;
+      }
+
+      // Sync mode (default): block until LLM responds, then fire.
       return captureCodeContext(stack)
         .then((codeContext) => {
           const context = {
@@ -390,9 +457,11 @@ class Ammo {
             method: this.method,
             path: this.path,
             includeDevInsight: true,
-            ...(throwOpts?.messageType && { messageType: throwOpts.messageType }),
+            ...(throwOpts?.messageType && {
+              messageType: throwOpts.messageType,
+            }),
           };
-          if (args[0] !== undefined && args[0] !== null) context.error = args[0];
+          if (originalError !== undefined) context.error = originalError;
           return inferErrorFromContext(context);
         })
         .then(({ statusCode, message, devInsight }) => {
@@ -402,6 +471,11 @@ class Ammo {
               ? { message, _dev: devInsight }
               : message;
           this.fire(statusCode, data);
+        })
+        .catch(() => {
+          // LLM call failed (network error, timeout, etc.) — fall back to generic 500
+          // so the client always gets a response and we don't trigger an infinite retry loop.
+          this.fire(500, 'Internal Server Error');
         });
     }
 

--- a/server/errors/channels/base.js
+++ b/server/errors/channels/base.js
@@ -1,0 +1,31 @@
+/**
+ * Base class for LLM error output channels.
+ * Subclasses implement dispatch() to send the LLM result wherever needed.
+ */
+
+/**
+ * @typedef {object} ChannelPayload
+ * @property {string} timestamp - ISO 8601 timestamp of when the error occurred
+ * @property {string} method - HTTP method (e.g. GET, POST)
+ * @property {string} path - Request path
+ * @property {number} statusCode - LLM-inferred HTTP status code
+ * @property {string} message - LLM-inferred message
+ * @property {string} [devInsight] - Developer insight from LLM (always included in async mode)
+ * @property {{ type: string, message: string } | null} error - Original error summary
+ * @property {{ snippets: Array<{ file: string, line: number, snippet: string }> }} codeContext - Source context
+ * @property {boolean} [cached] - Whether this result came from the cache
+ * @property {boolean} [rateLimited] - Whether LLM was skipped due to rate limiting
+ */
+
+export class ErrorChannel {
+  /**
+   * Dispatch an LLM error result to this channel.
+   * @param {ChannelPayload} payload
+   * @returns {Promise<void>}
+   */
+  async dispatch(payload) {
+    throw new Error(
+      `dispatch() must be implemented by ${this.constructor.name}`,
+    );
+  }
+}

--- a/server/errors/channels/console.js
+++ b/server/errors/channels/console.js
@@ -1,0 +1,64 @@
+/**
+ * Console channel: pretty-prints LLM error results to the terminal using ansi-colors.
+ */
+
+import ansi from 'ansi-colors';
+import { ErrorChannel } from './base.js';
+
+const { red, yellow, cyan, white, bold, dim, italic } = ansi;
+
+/**
+ * Format an HTTP status code with color (red for 5xx, yellow for 4xx, white for others).
+ * @param {number} statusCode
+ * @returns {string}
+ */
+function colorStatus(statusCode) {
+  if (statusCode >= 500) return red(bold(String(statusCode)));
+  if (statusCode >= 400) return yellow(bold(String(statusCode)));
+  return white(bold(String(statusCode)));
+}
+
+export class ConsoleChannel extends ErrorChannel {
+  async dispatch(payload) {
+    const {
+      timestamp,
+      method,
+      path,
+      statusCode,
+      message,
+      devInsight,
+      error,
+      cached,
+      rateLimited,
+    } = payload;
+
+    const time = dim(italic(new Date(timestamp).toLocaleTimeString()));
+    const route = white(`${method} ${path}`);
+    const status = colorStatus(statusCode);
+
+    const flags = [];
+    if (cached) flags.push(cyan('[CACHED]'));
+    if (rateLimited) flags.push(yellow('[RATE LIMITED]'));
+    const flagStr = flags.length ? ' ' + flags.join(' ') : '';
+
+    const lines = [
+      ``,
+      `${time} ${red('[LLM ERROR]')} ${route} → ${status}${flagStr}`,
+      `  ${white(message)}`,
+    ];
+
+    if (devInsight) {
+      lines.push(`  ${cyan('⟶')} ${cyan(devInsight)}`);
+    }
+
+    if (error?.message && !rateLimited) {
+      lines.push(
+        `  ${dim(`original: ${error.type ? error.type + ': ' : ''}${error.message}`)}`,
+      );
+    }
+
+    lines.push('');
+
+    process.stderr.write(lines.join('\n'));
+  }
+}

--- a/server/errors/channels/index.js
+++ b/server/errors/channels/index.js
@@ -1,0 +1,111 @@
+/**
+ * Channel registry for LLM error output.
+ * Maps channel config values ('console' | 'log' | 'both') to channel instances.
+ */
+
+import { ConsoleChannel } from './console.js';
+import { LogChannel } from './log.js';
+
+/** @type {ConsoleChannel|null} */
+let _console = null;
+
+/** @type {Map<string, LogChannel>} */
+const _logInstances = new Map();
+
+/**
+ * Get (or create) the singleton ConsoleChannel.
+ * @returns {ConsoleChannel}
+ */
+function getConsoleChannel() {
+  if (!_console) _console = new ConsoleChannel();
+  return _console;
+}
+
+/**
+ * Get (or create) a LogChannel for the given file path.
+ * @param {string} logFile
+ * @returns {LogChannel}
+ */
+function getLogChannel(logFile) {
+  if (!_logInstances.has(logFile)) {
+    _logInstances.set(logFile, new LogChannel(logFile));
+  }
+  return _logInstances.get(logFile);
+}
+
+/**
+ * Resolve channel instances for the given config value and log file.
+ * @param {'console'|'log'|'both'} channel
+ * @param {string} logFile
+ * @returns {import('./base.js').ErrorChannel[]}
+ */
+export function getChannels(channel, logFile) {
+  switch (channel) {
+    case 'log':
+      return [getLogChannel(logFile)];
+    case 'both':
+      return [getConsoleChannel(), getLogChannel(logFile)];
+    case 'console':
+    default:
+      return [getConsoleChannel()];
+  }
+}
+
+/**
+ * Build the standard channel payload from available context and LLM result.
+ * @param {object} opts
+ * @param {string} opts.method
+ * @param {string} opts.path
+ * @param {Error|string|null|undefined} opts.originalError
+ * @param {{ snippets: Array<{ file: string, line: number, snippet: string }> }} opts.codeContext
+ * @param {number} opts.statusCode
+ * @param {string} opts.message
+ * @param {string} [opts.devInsight]
+ * @param {boolean} [opts.cached]
+ * @param {boolean} [opts.rateLimited]
+ * @returns {import('./base.js').ChannelPayload}
+ */
+export function buildPayload({
+  method,
+  path,
+  originalError,
+  codeContext,
+  statusCode,
+  message,
+  devInsight,
+  cached,
+  rateLimited,
+}) {
+  let errorSummary = null;
+  if (originalError instanceof Error) {
+    errorSummary = {
+      type: originalError.constructor?.name ?? 'Error',
+      message: originalError.message ?? '',
+    };
+  } else if (originalError != null) {
+    errorSummary = { type: 'string', message: String(originalError) };
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    method: method ?? '',
+    path: path ?? '',
+    statusCode,
+    message,
+    ...(devInsight != null && { devInsight }),
+    error: errorSummary,
+    codeContext: codeContext ?? { snippets: [] },
+    ...(cached != null && { cached }),
+    ...(rateLimited != null && { rateLimited }),
+  };
+}
+
+/**
+ * Dispatch a payload to all resolved channels, swallowing individual channel errors.
+ * @param {import('./base.js').ErrorChannel[]} channels
+ * @param {import('./base.js').ChannelPayload} payload
+ * @returns {Promise<void>}
+ */
+export async function dispatchToChannels(channels, payload) {
+  await Promise.allSettled(channels.map((ch) => ch.dispatch(payload)));
+}

--- a/server/errors/channels/log.js
+++ b/server/errors/channels/log.js
@@ -1,0 +1,27 @@
+/**
+ * Log channel: appends a full JSONL entry to a log file for each LLM error result.
+ * Each line is a self-contained JSON object with all fields for post-mortem debugging.
+ */
+
+import { appendFile } from 'node:fs/promises';
+import { ErrorChannel } from './base.js';
+
+export class LogChannel extends ErrorChannel {
+  /**
+   * @param {string} logFile - Absolute or relative path to the JSONL log file.
+   */
+  constructor(logFile) {
+    super();
+    this.logFile = logFile;
+  }
+
+  async dispatch(payload) {
+    const line = JSON.stringify(payload) + '\n';
+    try {
+      await appendFile(this.logFile, line, 'utf-8');
+    } catch {
+      // Silently ignore write failures (e.g. permissions, disk full) so logging never
+      // crashes the process or blocks error handling.
+    }
+  }
+}

--- a/server/errors/llm-cache.js
+++ b/server/errors/llm-cache.js
@@ -1,0 +1,102 @@
+/**
+ * In-memory TTL cache for LLM error inference results.
+ * Key: file:line:errorMessage -- deduplicates repeated errors at the same throw site.
+ * Shared singleton across the process; configured from errors.llm.cacheTTL.
+ */
+
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000; // prune expired entries every 5 minutes
+
+class LLMErrorCache {
+  /**
+   * @param {number} ttl - Time-to-live in milliseconds for each cached result.
+   */
+  constructor(ttl) {
+    this.ttl = ttl > 0 ? ttl : 3_600_000;
+    /** @type {Map<string, { statusCode: number, message: string, devInsight?: string, cachedAt: number }>} */
+    this._store = new Map();
+    this._sweepTimer =
+      setInterval(() => this._sweep(), SWEEP_INTERVAL_MS).unref?.() ?? null;
+  }
+
+  /**
+   * Build a cache key from code context and error.
+   * Uses the first (throw-site) snippet's file and line + error text.
+   * @param {{ snippets?: Array<{ file: string, line: number }> }} codeContext
+   * @param {Error|string|undefined} error
+   * @returns {string}
+   */
+  buildKey(codeContext, error) {
+    const snippet = codeContext?.snippets?.[0];
+    const location = snippet ? `${snippet.file}:${snippet.line}` : 'unknown';
+    let errText = '';
+    if (error instanceof Error) {
+      errText = error.message ?? '';
+    } else if (error != null) {
+      errText = String(error);
+    }
+    return `${location}:${errText}`;
+  }
+
+  /**
+   * Get a cached result. Returns null if missing or expired (and prunes the entry).
+   * @param {string} key
+   * @returns {{ statusCode: number, message: string, devInsight?: string } | null}
+   */
+  get(key) {
+    const entry = this._store.get(key);
+    if (!entry) return null;
+    if (Date.now() - entry.cachedAt > this.ttl) {
+      this._store.delete(key);
+      return null;
+    }
+    const { cachedAt: _removed, ...result } = entry;
+    return result;
+  }
+
+  /**
+   * Store a result in the cache.
+   * @param {string} key
+   * @param {{ statusCode: number, message: string, devInsight?: string }} result
+   */
+  set(key, result) {
+    this._store.set(key, { ...result, cachedAt: Date.now() });
+  }
+
+  /**
+   * Remove all expired entries (called periodically by the sweep timer).
+   */
+  _sweep() {
+    const now = Date.now();
+    for (const [key, entry] of this._store) {
+      if (now - entry.cachedAt > this.ttl) {
+        this._store.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Number of entries currently in the cache (including potentially stale ones not yet swept).
+   * @returns {number}
+   */
+  get size() {
+    return this._store.size;
+  }
+}
+
+/** @type {LLMErrorCache|null} */
+let _instance = null;
+
+/**
+ * Get (or create) the singleton cache.
+ * Re-initializes if ttl changes.
+ * @param {number} ttl
+ * @returns {LLMErrorCache}
+ */
+export function getCache(ttl) {
+  if (!_instance || _instance.ttl !== ttl) {
+    _instance = new LLMErrorCache(ttl);
+  }
+  return _instance;
+}
+
+export { LLMErrorCache };

--- a/server/errors/llm-error-service.js
+++ b/server/errors/llm-error-service.js
@@ -3,11 +3,15 @@
  * returns statusCode and message (and optionally devInsight in non-production).
  * Uses shared lib/llm with errors.llm config. Developers do not pass an error object;
  * the LLM infers from the code where ammo.throw() was called.
+ *
+ * Flow: cache check -> rate limit check -> LLM call -> record rate -> store cache -> return.
  */
 
 import { createProvider } from '../../lib/llm/index.js';
 import { extractJSON } from '../../lib/llm/parse.js';
 import { getErrorsLlmConfig } from '../../utils/errors-llm-config.js';
+import { getRateLimiter } from './llm-rate-limiter.js';
+import { getCache } from './llm-cache.js';
 
 const DEFAULT_STATUS = 500;
 const DEFAULT_MESSAGE = 'Internal Server Error';
@@ -24,7 +28,8 @@ const DEFAULT_MESSAGE = 'Internal Server Error';
  * @returns {string}
  */
 function buildPrompt(context) {
-  const { codeContext, method, path, includeDevInsight, messageType, error } = context;
+  const { codeContext, method, path, includeDevInsight, messageType, error } =
+    context;
   const forDeveloper = messageType === 'developer';
 
   const requestPart = [method, path].filter(Boolean).length
@@ -35,7 +40,10 @@ function buildPrompt(context) {
   if (codeContext?.snippets?.length) {
     codePart = codeContext.snippets
       .map((s, i) => {
-        const label = i === 0 ? 'Call site (where ammo.throw() was invoked)' : `Upstream caller ${i}`;
+        const label =
+          i === 0
+            ? 'Call site (where ammo.throw() was invoked)'
+            : `Upstream caller ${i}`;
         return `--- ${label}: ${s.file} (line ${s.line}) ---\n${s.snippet}`;
       })
       .join('\n\n');
@@ -80,26 +88,64 @@ JSON:`;
 
 /**
  * Infer HTTP statusCode and message (and optionally devInsight) from code context using the LLM.
- * Uses errors.llm config (getErrorsLlmConfig). Call only when errors.llm.enabled is true and config is valid.
- * The primary input is codeContext (surrounding + upstream/downstream snippets); error is optional.
+ * Checks cache first, then rate limit. On success stores result in cache.
  *
  * @param {object} context - Context for the prompt.
- * @param {{ snippets: Array<{ file: string, line: number, snippet: string }> }} context.codeContext - Source snippets with line numbers (from captureCodeContext).
- * @param {string} [context.method] - HTTP method.
- * @param {string} [context.path] - Request path.
- * @param {boolean} [context.includeDevInsight] - In non-production, dev insight is included by default; set to false to disable.
- * @param {'endUser'|'developer'} [context.messageType] - Override config: 'endUser' or 'developer'. Default from errors.llm.messageType.
- * @param {string|Error|undefined} [context.error] - Optional error if the caller passed one (secondary signal).
- * @returns {Promise<{ statusCode: number, message: string, devInsight?: string }>}
+ * @param {{ snippets: Array<{ file: string, line: number, snippet: string }> }} context.codeContext
+ * @param {string} [context.method]
+ * @param {string} [context.path]
+ * @param {boolean} [context.includeDevInsight]
+ * @param {'endUser'|'developer'} [context.messageType]
+ * @param {string|Error|undefined} [context.error]
+ * @returns {Promise<{ statusCode: number, message: string, devInsight?: string, cached?: boolean, rateLimited?: boolean }>}
  */
 export async function inferErrorFromContext(context) {
   const config = getErrorsLlmConfig();
-  const { baseURL, apiKey, model, messageType: configMessageType } = config;
-  const provider = createProvider({ baseURL, apiKey, model });
+  const {
+    baseURL,
+    apiKey,
+    model,
+    messageType: configMessageType,
+    timeout,
+    rateLimit,
+    cache: cacheEnabled,
+    cacheTTL,
+  } = config;
 
   const isProduction = process.env.NODE_ENV === 'production';
-  const includeDevInsight = !isProduction && context.includeDevInsight !== false;
+  const includeDevInsight =
+    context.includeDevInsight !== false
+      ? context.forceDevInsight
+        ? true
+        : !isProduction
+      : false;
   const messageType = context.messageType ?? configMessageType;
+
+  // 1. Cache check
+  if (cacheEnabled) {
+    const cache = getCache(cacheTTL);
+    const key = cache.buildKey(context.codeContext, context.error);
+    const cached = cache.get(key);
+    if (cached) {
+      return { ...cached, cached: true };
+    }
+  }
+
+  // 2. Rate limit check
+  const limiter = getRateLimiter(rateLimit);
+  if (!limiter.canCall()) {
+    return {
+      statusCode: DEFAULT_STATUS,
+      message: DEFAULT_MESSAGE,
+      ...(includeDevInsight && {
+        devInsight: 'LLM rate limit exceeded — error was not enhanced.',
+      }),
+      rateLimited: true,
+    };
+  }
+
+  // 3. LLM call
+  const provider = createProvider({ baseURL, apiKey, model, timeout });
 
   const prompt = buildPrompt({
     codeContext: context.codeContext,
@@ -111,6 +157,10 @@ export async function inferErrorFromContext(context) {
   });
 
   const { content } = await provider.analyze(prompt);
+
+  // 4. Record the call against the rate limit
+  limiter.record();
+
   const parsed = extractJSON(content);
 
   if (!parsed || typeof parsed !== 'object') {
@@ -132,8 +182,19 @@ export async function inferErrorFromContext(context) {
       : DEFAULT_MESSAGE;
 
   const result = { statusCode, message };
-  if (includeDevInsight && typeof parsed.devInsight === 'string' && parsed.devInsight.trim()) {
+  if (
+    includeDevInsight &&
+    typeof parsed.devInsight === 'string' &&
+    parsed.devInsight.trim()
+  ) {
     result.devInsight = parsed.devInsight.trim();
+  }
+
+  // 5. Store in cache
+  if (cacheEnabled) {
+    const cache = getCache(cacheTTL);
+    const key = cache.buildKey(context.codeContext, context.error);
+    cache.set(key, result);
   }
 
   return result;

--- a/server/errors/llm-rate-limiter.js
+++ b/server/errors/llm-rate-limiter.js
@@ -1,0 +1,72 @@
+/**
+ * In-memory sliding window rate limiter for LLM error inference calls.
+ * Tracks LLM call timestamps in the last 60 seconds.
+ * Shared singleton across the process; configured from errors.llm.rateLimit.
+ */
+
+class LLMRateLimiter {
+  /**
+   * @param {number} maxPerMinute - Maximum LLM calls allowed per 60-second window.
+   */
+  constructor(maxPerMinute) {
+    this.maxPerMinute = maxPerMinute > 0 ? Math.floor(maxPerMinute) : 10;
+    /** @type {number[]} timestamps of recent LLM calls (ms since epoch) */
+    this._timestamps = [];
+  }
+
+  /**
+   * Prune timestamps older than 60 seconds from now.
+   */
+  _prune() {
+    const cutoff = Date.now() - 60_000;
+    let i = 0;
+    while (i < this._timestamps.length && this._timestamps[i] <= cutoff) {
+      i++;
+    }
+    if (i > 0) this._timestamps.splice(0, i);
+  }
+
+  /**
+   * Returns true if an LLM call is allowed under the current rate.
+   * @returns {boolean}
+   */
+  canCall() {
+    this._prune();
+    return this._timestamps.length < this.maxPerMinute;
+  }
+
+  /**
+   * Record that an LLM call was made right now.
+   */
+  record() {
+    this._prune();
+    this._timestamps.push(Date.now());
+  }
+
+  /**
+   * Returns how many calls remain in the current window.
+   * @returns {number}
+   */
+  remaining() {
+    this._prune();
+    return Math.max(0, this.maxPerMinute - this._timestamps.length);
+  }
+}
+
+/** @type {LLMRateLimiter|null} */
+let _instance = null;
+
+/**
+ * Get (or create) the singleton rate limiter.
+ * Re-initializes if maxPerMinute changes.
+ * @param {number} maxPerMinute
+ * @returns {LLMRateLimiter}
+ */
+export function getRateLimiter(maxPerMinute) {
+  if (!_instance || _instance.maxPerMinute !== maxPerMinute) {
+    _instance = new LLMRateLimiter(maxPerMinute);
+  }
+  return _instance;
+}
+
+export { LLMRateLimiter };

--- a/server/handler.js
+++ b/server/handler.js
@@ -165,7 +165,8 @@ const handler = async (req, res) => {
         }
       }
 
-      // Add route parameters to ammo.payload
+      // Add route parameters to ammo.params and ammo.payload
+      ammo.params = match.params || {};
       if (match.params && Object.keys(match.params).length > 0) {
         Object.assign(ammo.payload, match.params);
       }

--- a/server/handler.js
+++ b/server/handler.js
@@ -112,7 +112,8 @@ const executeChain = async (target, ammo) => {
  * @returns {Promise<void>}
  */
 const errorHandler = async (ammo, err) => {
-  if (env('LOG_EXCEPTIONS')) errorLogger.error(err);
+  // Pass false as second arg to suppress tej-logger's Console.trace() double-stack output.
+  if (env('LOG_EXCEPTIONS')) errorLogger.error(err, false);
 
   const result = ammo.throw(err);
   if (result != null && typeof result.then === 'function') {

--- a/server/targets/registry.js
+++ b/server/targets/registry.js
@@ -94,14 +94,14 @@ class TargetRegistry {
     const patternSegments = pattern.split('/').filter((s) => s.length > 0);
     const urlSegments = url.split('/').filter((s) => s.length > 0);
 
-    // Must have same number of segments
-    if (patternSegments.length !== urlSegments.length) {
-      return null;
-    }
-
     // If both are empty (root paths), they match
     if (patternSegments.length === 0 && urlSegments.length === 0) {
       return {};
+    }
+
+    // Must have same number of segments
+    if (patternSegments.length !== urlSegments.length) {
+      return null;
     }
 
     const params = {};
@@ -133,7 +133,7 @@ class TargetRegistry {
    */
   getAllEndpoints(options = {}) {
     const grouped =
-      typeof options === 'boolean' ? options : (options && options.grouped);
+      typeof options === 'boolean' ? options : options && options.grouped;
     const detailed =
       typeof options === 'object' && options && options.detailed === true;
 

--- a/te.js
+++ b/te.js
@@ -10,7 +10,10 @@ import dbManager from './database/index.js';
 import { loadConfigFile, standardizeObj } from './utils/configuration.js';
 
 import targetHandler from './server/handler.js';
-import { getErrorsLlmConfig, validateErrorsLlmAtTakeoff } from './utils/errors-llm-config.js';
+import {
+  getErrorsLlmConfig,
+  validateErrorsLlmAtTakeoff,
+} from './utils/errors-llm-config.js';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { readFile } from 'node:fs/promises';
@@ -133,10 +136,9 @@ class Tejas {
               ? path.join(parentPath, file.name)
               : path.join(baseDir, parentPath, file.name);
             const relativePath = path.relative(baseDir, fullPath);
-            const groupId = relativePath
-              .replace(/\.target\.js$/i, '')
-              .replace(/\\/g, '/')
-              || 'index';
+            const groupId =
+              relativePath.replace(/\.target\.js$/i, '').replace(/\\/g, '/') ||
+              'index';
             targetRegistry.setCurrentSourceGroup(groupId);
             try {
               await import(pathToFileURL(fullPath).href);
@@ -305,14 +307,21 @@ class Tejas {
 
   /**
    * Enables LLM-inferred error codes and messages for ammo.throw() and framework-caught errors.
-   * Call before takeoff(). Remaining options (baseURL, apiKey, model, messageType) can come from
-   * config, or from env/tejas.config.json (LLM_* / ERRORS_LLM_*). Validation runs at takeoff.
+   * Call before takeoff(). Remaining options can come from env/tejas.config.json (LLM_* / ERRORS_LLM_*).
+   * Validation runs at takeoff.
    *
    * @param {Object} [config] - Optional errors.llm overrides
    * @param {string} [config.baseURL] - LLM provider endpoint (e.g. https://api.openai.com/v1)
    * @param {string} [config.apiKey] - LLM provider API key
    * @param {string} [config.model] - Model name (e.g. gpt-4o-mini)
    * @param {'endUser'|'developer'} [config.messageType] - Default message tone
+   * @param {'sync'|'async'} [config.mode] - 'sync' blocks the response until LLM returns (default); 'async' responds immediately with 500 and dispatches LLM result to a channel
+   * @param {number} [config.timeout] - LLM fetch timeout in milliseconds (default 10000)
+   * @param {'console'|'log'|'both'} [config.channel] - Output channel for async mode results (default 'console')
+   * @param {string} [config.logFile] - Path to JSONL log file used by 'log' and 'both' channels (default './errors.llm.log')
+   * @param {number} [config.rateLimit] - Max LLM calls per minute across all requests (default 10)
+   * @param {boolean} [config.cache] - Cache LLM results by throw site + error message to avoid repeated calls (default true)
+   * @param {number} [config.cacheTTL] - How long cached results are reused in milliseconds (default 3600000 = 1 hour)
    * @returns {Tejas} The Tejas instance for chaining
    *
    * @example
@@ -322,6 +331,10 @@ class Tejas {
    * @example
    * app.withLLMErrors({ baseURL: 'https://api.openai.com/v1', apiKey: process.env.OPENAI_KEY, model: 'gpt-4o-mini' });
    * app.takeoff();
+   *
+   * @example
+   * app.withLLMErrors({ mode: 'async', channel: 'both', rateLimit: 20 });
+   * app.takeoff();
    */
   withLLMErrors(config) {
     setEnv('ERRORS_LLM_ENABLED', true);
@@ -329,7 +342,17 @@ class Tejas {
       if (config.baseURL != null) setEnv('ERRORS_LLM_BASE_URL', config.baseURL);
       if (config.apiKey != null) setEnv('ERRORS_LLM_API_KEY', config.apiKey);
       if (config.model != null) setEnv('ERRORS_LLM_MODEL', config.model);
-      if (config.messageType != null) setEnv('ERRORS_LLM_MESSAGE_TYPE', config.messageType);
+      if (config.messageType != null)
+        setEnv('ERRORS_LLM_MESSAGE_TYPE', config.messageType);
+      if (config.mode != null) setEnv('ERRORS_LLM_MODE', config.mode);
+      if (config.timeout != null) setEnv('ERRORS_LLM_TIMEOUT', config.timeout);
+      if (config.channel != null) setEnv('ERRORS_LLM_CHANNEL', config.channel);
+      if (config.logFile != null) setEnv('ERRORS_LLM_LOG_FILE', config.logFile);
+      if (config.rateLimit != null)
+        setEnv('ERRORS_LLM_RATE_LIMIT', config.rateLimit);
+      if (config.cache != null) setEnv('ERRORS_LLM_CACHE', config.cache);
+      if (config.cacheTTL != null)
+        setEnv('ERRORS_LLM_CACHE_TTL', config.cacheTTL);
     }
     return this;
   }
@@ -401,16 +424,21 @@ class Tejas {
    * app.takeoff();
    */
   serveDocs(config = {}) {
-    const specPath = path.resolve(process.cwd(), config.specPath || './openapi.json');
+    const specPath = path.resolve(
+      process.cwd(),
+      config.specPath || './openapi.json',
+    );
     const { scalarConfig } = config;
     const getSpec = async () => {
       const content = await readFile(specPath, 'utf8');
       return JSON.parse(content);
     };
-    registerDocRoutes({ getSpec, specUrl: '/docs/openapi.json', scalarConfig }, targetRegistry);
+    registerDocRoutes(
+      { getSpec, specUrl: '/docs/openapi.json', scalarConfig },
+      targetRegistry,
+    );
     return this;
   }
-
 }
 
 const listAllEndpoints = (grouped = false) => {

--- a/tests/errors/channels.test.js
+++ b/tests/errors/channels.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getChannels,
+  buildPayload,
+} from '../../server/errors/channels/index.js';
+import { ConsoleChannel } from '../../server/errors/channels/console.js';
+import { LogChannel } from '../../server/errors/channels/log.js';
+
+describe('getChannels()', () => {
+  it('returns a ConsoleChannel for "console"', () => {
+    const channels = getChannels('console', './test.log');
+    expect(channels).toHaveLength(1);
+    expect(channels[0]).toBeInstanceOf(ConsoleChannel);
+  });
+
+  it('returns a LogChannel for "log"', () => {
+    const channels = getChannels('log', './test.log');
+    expect(channels).toHaveLength(1);
+    expect(channels[0]).toBeInstanceOf(LogChannel);
+  });
+
+  it('returns both channels for "both"', () => {
+    const channels = getChannels('both', './test.log');
+    expect(channels).toHaveLength(2);
+    const types = channels.map((c) => c.constructor.name);
+    expect(types).toContain('ConsoleChannel');
+    expect(types).toContain('LogChannel');
+  });
+
+  it('defaults to ConsoleChannel for unknown values', () => {
+    const channels = getChannels('unknown', './test.log');
+    expect(channels).toHaveLength(1);
+    expect(channels[0]).toBeInstanceOf(ConsoleChannel);
+  });
+
+  it('returns same ConsoleChannel singleton across calls', () => {
+    const a = getChannels('console', './test.log')[0];
+    const b = getChannels('console', './test.log')[0];
+    expect(a).toBe(b);
+  });
+
+  it('LogChannel uses the provided logFile path', () => {
+    const channels = getChannels('log', './my-errors.log');
+    expect(channels[0].logFile).toBe('./my-errors.log');
+  });
+});
+
+describe('buildPayload()', () => {
+  const codeContext = {
+    snippets: [
+      { file: '/app/handler.js', line: 10, snippet: '→ ammo.throw()' },
+    ],
+  };
+
+  it('builds a complete payload', () => {
+    const payload = buildPayload({
+      method: 'POST',
+      path: '/users',
+      originalError: new Error('DB error'),
+      codeContext,
+      statusCode: 500,
+      message: 'Internal Server Error',
+      devInsight: 'DB connection may be down.',
+    });
+
+    expect(payload.method).toBe('POST');
+    expect(payload.path).toBe('/users');
+    expect(payload.statusCode).toBe(500);
+    expect(payload.message).toBe('Internal Server Error');
+    expect(payload.devInsight).toBe('DB connection may be down.');
+    expect(payload.error).toEqual({ type: 'Error', message: 'DB error' });
+    expect(payload.codeContext).toBe(codeContext);
+    expect(typeof payload.timestamp).toBe('string');
+    // ISO string
+    expect(() => new Date(payload.timestamp)).not.toThrow();
+  });
+
+  it('handles string error', () => {
+    const payload = buildPayload({
+      method: 'GET',
+      path: '/items',
+      originalError: 'Not found',
+      codeContext,
+      statusCode: 404,
+      message: 'Not found',
+    });
+    expect(payload.error).toEqual({ type: 'string', message: 'Not found' });
+  });
+
+  it('sets error to null when no originalError', () => {
+    const payload = buildPayload({
+      method: 'GET',
+      path: '/',
+      originalError: null,
+      codeContext,
+      statusCode: 500,
+      message: 'Error',
+    });
+    expect(payload.error).toBeNull();
+  });
+
+  it('includes cached flag when provided', () => {
+    const payload = buildPayload({
+      method: 'GET',
+      path: '/',
+      originalError: null,
+      codeContext,
+      statusCode: 404,
+      message: 'Not found',
+      cached: true,
+    });
+    expect(payload.cached).toBe(true);
+  });
+
+  it('includes rateLimited flag when provided', () => {
+    const payload = buildPayload({
+      method: 'GET',
+      path: '/',
+      originalError: null,
+      codeContext,
+      statusCode: 500,
+      message: 'Error',
+      rateLimited: true,
+    });
+    expect(payload.rateLimited).toBe(true);
+  });
+
+  it('omits cached and rateLimited when not provided', () => {
+    const payload = buildPayload({
+      method: 'GET',
+      path: '/',
+      originalError: null,
+      codeContext,
+      statusCode: 200,
+      message: 'OK',
+    });
+    expect(payload).not.toHaveProperty('cached');
+    expect(payload).not.toHaveProperty('rateLimited');
+  });
+
+  it('omits devInsight when not provided', () => {
+    const payload = buildPayload({
+      method: 'GET',
+      path: '/',
+      originalError: null,
+      codeContext,
+      statusCode: 500,
+      message: 'Error',
+    });
+    expect(payload).not.toHaveProperty('devInsight');
+  });
+});

--- a/tests/errors/llm-cache.test.js
+++ b/tests/errors/llm-cache.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { LLMErrorCache, getCache } from '../../server/errors/llm-cache.js';
+
+describe('LLMErrorCache', () => {
+  describe('constructor', () => {
+    it('uses provided ttl', () => {
+      const cache = new LLMErrorCache(5000);
+      expect(cache.ttl).toBe(5000);
+    });
+
+    it('defaults to 3600000 for invalid ttl', () => {
+      expect(new LLMErrorCache(0).ttl).toBe(3_600_000);
+      expect(new LLMErrorCache(-1).ttl).toBe(3_600_000);
+    });
+  });
+
+  describe('buildKey()', () => {
+    it('builds key from first snippet file, line, and error message', () => {
+      const cache = new LLMErrorCache(1000);
+      const codeContext = {
+        snippets: [{ file: '/app/routes/users.js', line: 42 }],
+      };
+      const error = new Error('User not found');
+      const key = cache.buildKey(codeContext, error);
+      expect(key).toBe('/app/routes/users.js:42:User not found');
+    });
+
+    it('handles string error', () => {
+      const cache = new LLMErrorCache(1000);
+      const codeContext = { snippets: [{ file: '/app/handler.js', line: 10 }] };
+      const key = cache.buildKey(codeContext, 'Validation failed');
+      expect(key).toBe('/app/handler.js:10:Validation failed');
+    });
+
+    it('handles no error (empty string suffix)', () => {
+      const cache = new LLMErrorCache(1000);
+      const codeContext = { snippets: [{ file: '/app/handler.js', line: 5 }] };
+      const key = cache.buildKey(codeContext, undefined);
+      expect(key).toBe('/app/handler.js:5:');
+    });
+
+    it('uses "unknown" when codeContext has no snippets', () => {
+      const cache = new LLMErrorCache(1000);
+      const key = cache.buildKey({ snippets: [] }, new Error('oops'));
+      expect(key).toBe('unknown:oops');
+    });
+
+    it('uses "unknown" when codeContext is missing', () => {
+      const cache = new LLMErrorCache(1000);
+      const key = cache.buildKey(null, new Error('oops'));
+      expect(key).toBe('unknown:oops');
+    });
+  });
+
+  describe('set() and get()', () => {
+    it('stores and retrieves a result', () => {
+      const cache = new LLMErrorCache(10_000);
+      cache.set('key1', { statusCode: 404, message: 'Not found' });
+      const result = cache.get('key1');
+      expect(result).toEqual({ statusCode: 404, message: 'Not found' });
+    });
+
+    it('returns null for missing keys', () => {
+      const cache = new LLMErrorCache(10_000);
+      expect(cache.get('nonexistent')).toBeNull();
+    });
+
+    it('does not return cachedAt in the result', () => {
+      const cache = new LLMErrorCache(10_000);
+      cache.set('key1', { statusCode: 500, message: 'Error' });
+      const result = cache.get('key1');
+      expect(result).not.toHaveProperty('cachedAt');
+    });
+
+    it('includes devInsight when stored', () => {
+      const cache = new LLMErrorCache(10_000);
+      cache.set('key1', {
+        statusCode: 404,
+        message: 'Not found',
+        devInsight: 'Check the ID param.',
+      });
+      const result = cache.get('key1');
+      expect(result.devInsight).toBe('Check the ID param.');
+    });
+  });
+
+  describe('TTL expiry', () => {
+    it('returns null for expired entries', () => {
+      vi.useFakeTimers();
+
+      const cache = new LLMErrorCache(1000); // 1 second TTL
+      cache.set('key1', { statusCode: 404, message: 'Not found' });
+      expect(cache.get('key1')).not.toBeNull();
+
+      vi.advanceTimersByTime(1001);
+
+      expect(cache.get('key1')).toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it('removes expired entry from the store on access', () => {
+      vi.useFakeTimers();
+
+      const cache = new LLMErrorCache(500);
+      cache.set('key1', { statusCode: 500, message: 'Error' });
+      expect(cache.size).toBe(1);
+
+      vi.advanceTimersByTime(600);
+      cache.get('key1'); // should prune
+
+      expect(cache.size).toBe(0);
+
+      vi.useRealTimers();
+    });
+
+    it('non-expired entries remain accessible', () => {
+      vi.useFakeTimers();
+
+      const cache = new LLMErrorCache(5000);
+      cache.set('key1', { statusCode: 200, message: 'OK' });
+
+      vi.advanceTimersByTime(4999);
+
+      expect(cache.get('key1')).not.toBeNull();
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('size', () => {
+    it('tracks the number of entries', () => {
+      const cache = new LLMErrorCache(10_000);
+      expect(cache.size).toBe(0);
+      cache.set('a', { statusCode: 200, message: 'OK' });
+      cache.set('b', { statusCode: 404, message: 'Not found' });
+      expect(cache.size).toBe(2);
+    });
+  });
+});
+
+describe('getCache (singleton)', () => {
+  it('returns a LLMErrorCache instance', () => {
+    const cache = getCache(3600000);
+    expect(cache).toBeInstanceOf(LLMErrorCache);
+  });
+
+  it('returns same instance for same ttl', () => {
+    const a = getCache(3600000);
+    const b = getCache(3600000);
+    expect(a).toBe(b);
+  });
+
+  it('creates a new instance when ttl changes', () => {
+    const a = getCache(1000);
+    const b = getCache(2000);
+    expect(a).not.toBe(b);
+    expect(b.ttl).toBe(2000);
+  });
+});

--- a/tests/errors/llm-rate-limiter.test.js
+++ b/tests/errors/llm-rate-limiter.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  LLMRateLimiter,
+  getRateLimiter,
+} from '../../server/errors/llm-rate-limiter.js';
+
+describe('LLMRateLimiter', () => {
+  describe('constructor', () => {
+    it('uses provided maxPerMinute', () => {
+      const limiter = new LLMRateLimiter(5);
+      expect(limiter.maxPerMinute).toBe(5);
+    });
+
+    it('defaults to 10 when maxPerMinute is invalid', () => {
+      expect(new LLMRateLimiter(0).maxPerMinute).toBe(10);
+      expect(new LLMRateLimiter(-1).maxPerMinute).toBe(10);
+    });
+
+    it('floors non-integer values', () => {
+      expect(new LLMRateLimiter(4.9).maxPerMinute).toBe(4);
+    });
+  });
+
+  describe('canCall() and record()', () => {
+    it('allows calls when under the limit', () => {
+      const limiter = new LLMRateLimiter(3);
+      expect(limiter.canCall()).toBe(true);
+    });
+
+    it('blocks calls when at the limit', () => {
+      const limiter = new LLMRateLimiter(2);
+      limiter.record();
+      limiter.record();
+      expect(limiter.canCall()).toBe(false);
+    });
+
+    it('allows calls again after recording up to max', () => {
+      const limiter = new LLMRateLimiter(1);
+      expect(limiter.canCall()).toBe(true);
+      limiter.record();
+      expect(limiter.canCall()).toBe(false);
+    });
+
+    it('remaining() returns correct count', () => {
+      const limiter = new LLMRateLimiter(3);
+      expect(limiter.remaining()).toBe(3);
+      limiter.record();
+      expect(limiter.remaining()).toBe(2);
+      limiter.record();
+      expect(limiter.remaining()).toBe(1);
+      limiter.record();
+      expect(limiter.remaining()).toBe(0);
+    });
+  });
+
+  describe('sliding window pruning', () => {
+    it('expires old timestamps after 60 seconds', () => {
+      vi.useFakeTimers();
+
+      const limiter = new LLMRateLimiter(2);
+      limiter.record();
+      limiter.record();
+      expect(limiter.canCall()).toBe(false);
+
+      // Advance time past 60 seconds
+      vi.advanceTimersByTime(61_000);
+
+      expect(limiter.canCall()).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    it('only expires timestamps older than 60 seconds', () => {
+      vi.useFakeTimers();
+
+      const limiter = new LLMRateLimiter(2);
+      limiter.record(); // at t=0
+
+      vi.advanceTimersByTime(50_000); // t=50s
+      limiter.record(); // at t=50s
+
+      vi.advanceTimersByTime(15_000); // t=65s — first record is now 65s old, second is 15s old
+      expect(limiter.canCall()).toBe(true); // first expired, second still active → 1/2 used
+      expect(limiter.remaining()).toBe(1);
+
+      vi.useRealTimers();
+    });
+  });
+});
+
+describe('getRateLimiter (singleton)', () => {
+  it('returns a LLMRateLimiter instance', () => {
+    const limiter = getRateLimiter(10);
+    expect(limiter).toBeInstanceOf(LLMRateLimiter);
+  });
+
+  it('returns same instance for same maxPerMinute', () => {
+    const a = getRateLimiter(10);
+    const b = getRateLimiter(10);
+    expect(a).toBe(b);
+  });
+
+  it('creates a new instance when maxPerMinute changes', () => {
+    const a = getRateLimiter(5);
+    const b = getRateLimiter(15);
+    expect(a).not.toBe(b);
+    expect(b.maxPerMinute).toBe(15);
+  });
+});

--- a/utils/errors-llm-config.js
+++ b/utils/errors-llm-config.js
@@ -7,6 +7,8 @@
 import { env } from 'tej-env';
 
 const MESSAGE_TYPES = /** @type {const} */ (['endUser', 'developer']);
+const LLM_MODES = /** @type {const} */ (['sync', 'async']);
+const LLM_CHANNELS = /** @type {const} */ (['console', 'log', 'both']);
 
 /**
  * Normalize messageType to 'endUser' | 'developer'.
@@ -14,14 +16,56 @@ const MESSAGE_TYPES = /** @type {const} */ (['endUser', 'developer']);
  * @returns {'endUser'|'developer'}
  */
 function normalizeMessageType(v) {
-  const s = String(v ?? '').trim().toLowerCase();
+  const s = String(v ?? '')
+    .trim()
+    .toLowerCase();
   if (s === 'developer' || s === 'dev') return 'developer';
   return 'endUser'; // endUser, end_user, default
 }
 
 /**
+ * Normalize mode to 'sync' | 'async'.
+ * @param {string} v
+ * @returns {'sync'|'async'}
+ */
+function normalizeMode(v) {
+  const s = String(v ?? '')
+    .trim()
+    .toLowerCase();
+  if (s === 'async') return 'async';
+  return 'sync';
+}
+
+/**
+ * Normalize channel to 'console' | 'log' | 'both'.
+ * @param {string} v
+ * @returns {'console'|'log'|'both'}
+ */
+function normalizeChannel(v) {
+  const s = String(v ?? '')
+    .trim()
+    .toLowerCase();
+  if (s === 'log') return 'log';
+  if (s === 'both') return 'both';
+  return 'console';
+}
+
+/**
  * Resolve errors.llm config from env (feature-specific then LLM_ fallback).
- * @returns {{ enabled: boolean, baseURL: string, apiKey: string, model: string, messageType: 'endUser'|'developer' }}
+ * @returns {{
+ *   enabled: boolean,
+ *   baseURL: string,
+ *   apiKey: string,
+ *   model: string,
+ *   messageType: 'endUser'|'developer',
+ *   mode: 'sync'|'async',
+ *   timeout: number,
+ *   channel: 'console'|'log'|'both',
+ *   logFile: string,
+ *   rateLimit: number,
+ *   cache: boolean,
+ *   cacheTTL: number,
+ * }}
  */
 export function getErrorsLlmConfig() {
   const enabledRaw = env('ERRORS_LLM_ENABLED') ?? '';
@@ -45,11 +89,50 @@ export function getErrorsLlmConfig() {
     env('LLM_APIKEY') ??
     '';
 
-  const model =
-    env('ERRORS_LLM_MODEL') ?? env('LLM_MODEL') ?? '';
+  const model = env('ERRORS_LLM_MODEL') ?? env('LLM_MODEL') ?? '';
 
   const messageTypeRaw =
-    env('ERRORS_LLM_MESSAGE_TYPE') ?? env('ERRORS_LLM_MESSAGETYPE') ?? env('LLM_MESSAGE_TYPE') ?? env('LLM_MESSAGETYPE') ?? '';
+    env('ERRORS_LLM_MESSAGE_TYPE') ??
+    env('ERRORS_LLM_MESSAGETYPE') ??
+    env('LLM_MESSAGE_TYPE') ??
+    env('LLM_MESSAGETYPE') ??
+    '';
+
+  const modeRaw = env('ERRORS_LLM_MODE') ?? env('LLM_MODE') ?? '';
+
+  const timeoutRaw = env('ERRORS_LLM_TIMEOUT') ?? env('LLM_TIMEOUT') ?? '';
+  const timeoutNum = Number(timeoutRaw);
+  const timeout =
+    !timeoutRaw || isNaN(timeoutNum) || timeoutNum <= 0 ? 10000 : timeoutNum;
+
+  const channelRaw = env('ERRORS_LLM_CHANNEL') ?? env('LLM_CHANNEL') ?? '';
+
+  const logFile =
+    String(env('ERRORS_LLM_LOG_FILE') ?? '').trim() || './errors.llm.log';
+
+  const rateLimitRaw =
+    env('ERRORS_LLM_RATE_LIMIT') ?? env('LLM_RATE_LIMIT') ?? '';
+  const rateLimitNum = Number(rateLimitRaw);
+  const rateLimit =
+    !rateLimitRaw || isNaN(rateLimitNum) || rateLimitNum <= 0
+      ? 10
+      : Math.floor(rateLimitNum);
+
+  const cacheRaw = env('ERRORS_LLM_CACHE') ?? '';
+  const cache =
+    cacheRaw === false ||
+    cacheRaw === 'false' ||
+    cacheRaw === '0' ||
+    cacheRaw === 0
+      ? false
+      : true;
+
+  const cacheTTLRaw = env('ERRORS_LLM_CACHE_TTL') ?? '';
+  const cacheTTLNum = Number(cacheTTLRaw);
+  const cacheTTL =
+    !cacheTTLRaw || isNaN(cacheTTLNum) || cacheTTLNum <= 0
+      ? 3600000
+      : cacheTTLNum;
 
   return {
     enabled: Boolean(enabled),
@@ -57,18 +140,35 @@ export function getErrorsLlmConfig() {
     apiKey: String(apiKey ?? '').trim(),
     model: String(model ?? '').trim(),
     messageType: normalizeMessageType(messageTypeRaw || 'endUser'),
+    mode: normalizeMode(modeRaw),
+    timeout,
+    channel: normalizeChannel(channelRaw),
+    logFile,
+    rateLimit,
+    cache,
+    cacheTTL,
   };
 }
 
-export { MESSAGE_TYPES };
+export { MESSAGE_TYPES, LLM_MODES, LLM_CHANNELS };
 
 /**
  * Validate errors.llm when enabled: require baseURL, apiKey, and model (after LLM_ fallback).
+ * Also warns about misconfigurations (e.g. channel set with sync mode).
  * Call at takeoff. Throws if enabled but config is invalid; no-op otherwise.
  * @throws {Error} If errors.llm.enabled is true but any of baseURL, apiKey, or model is missing
  */
 export function validateErrorsLlmAtTakeoff() {
-  const { enabled, baseURL, apiKey, model } = getErrorsLlmConfig();
+  const {
+    enabled,
+    baseURL,
+    apiKey,
+    model,
+    mode,
+    channel,
+    rateLimit,
+    cacheTTL,
+  } = getErrorsLlmConfig();
   if (!enabled) return;
 
   const missing = [];
@@ -79,6 +179,36 @@ export function validateErrorsLlmAtTakeoff() {
   if (missing.length > 0) {
     throw new Error(
       `errors.llm is enabled but required config is missing: ${missing.join(', ')}. Set these env vars or disable errors.llm.enabled.`,
+    );
+  }
+
+  // Warn about channel set while mode is sync (channel only applies in async mode).
+  const channelRaw = String(
+    env('ERRORS_LLM_CHANNEL') ?? env('LLM_CHANNEL') ?? '',
+  ).trim();
+  if (mode === 'sync' && channelRaw) {
+    console.warn(
+      `[Tejas] errors.llm: channel="${channel}" is set but mode is "sync" — channel output only applies in async mode. Set ERRORS_LLM_MODE=async to use it.`,
+    );
+  }
+
+  // Warn about invalid numeric values that were silently reset to defaults.
+  const rateLimitRaw = String(
+    env('ERRORS_LLM_RATE_LIMIT') ?? env('LLM_RATE_LIMIT') ?? '',
+  ).trim();
+  if (
+    rateLimitRaw &&
+    (isNaN(Number(rateLimitRaw)) || Number(rateLimitRaw) <= 0)
+  ) {
+    console.warn(
+      `[Tejas] errors.llm: rateLimit value "${rateLimitRaw}" is invalid; defaulting to 10.`,
+    );
+  }
+
+  const cacheTTLRaw = String(env('ERRORS_LLM_CACHE_TTL') ?? '').trim();
+  if (cacheTTLRaw && (isNaN(Number(cacheTTLRaw)) || Number(cacheTTLRaw) <= 0)) {
+    console.warn(
+      `[Tejas] errors.llm: cacheTTL value "${cacheTTLRaw}" is invalid; defaulting to 3600000.`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- **Async error mode**: New `errors.llm.mode: 'async'` option responds immediately with a generic 500 and runs LLM inference in the background, dispatching results to configurable output channels (`console`, `log`, or `both`). Eliminates LLM latency from the HTTP response path.
- **Rate limiting & caching**: Adds per-minute rate limiting (`errors.llm.rateLimit`, default 10) to prevent API quota exhaustion during error bursts, and throw-site + message caching (`errors.llm.cache` with configurable TTL) to avoid redundant LLM calls for repeated errors.
- **Route parameter support**: `ammo.params` is now populated from parameterized routes (e.g. `/:id`), in addition to the existing `ammo.payload` merge. Handlers can read `ammo.params.id` directly.
- **404 global middleware execution**: Unmatched routes now run the full global middleware chain (CORS, auth, logging, etc.) before returning 404, instead of bypassing middlewares entirely.

### New configuration options

| Option | Default | Description |
|---|---|---|
| `errors.llm.mode` | `sync` | `sync` blocks response; `async` responds immediately |
| `errors.llm.timeout` | `10000` | LLM call timeout in ms |
| `errors.llm.channel` | `console` | Output channel for async results |
| `errors.llm.logFile` | `./errors.llm.log` | JSONL log path for `log`/`both` channels |
| `errors.llm.rateLimit` | `10` | Max LLM calls per minute |
| `errors.llm.cache` | `true` | Cache results by throw site + error |
| `errors.llm.cacheTTL` | `3600000` | Cache TTL (1 hour default) |

All options are configurable via `tejas.config.json`, environment variables, or `app.withLLMErrors()`.

### Files changed (19 files, +1418 / -136)

**Core**
- `server/handler.js` — route param assignment (`ammo.params`), 404 middleware chain
- `server/ammo.js` — async throw path, per-call options, timeout support
- `server/errors/llm-error-service.js` — async dispatch, rate limit + cache integration
- `server/targets/registry.js` — detailed endpoint listing for docs

**New modules**
- `server/errors/channels/` — base, console, log channel implementations + index (factory)
- `server/errors/llm-cache.js` — in-memory LRU cache keyed by file:line:message
- `server/errors/llm-rate-limiter.js` — sliding-window rate limiter

**Config & docs**
- `utils/errors-llm-config.js` — new option parsing (mode, timeout, channel, rateLimit, cache, cacheTTL)
- `docs/configuration.md` & `docs/error-handling.md` — full documentation for all new features

**Tests**
- `tests/errors/channels.test.js` — channel dispatch tests
- `tests/errors/llm-cache.test.js` — cache set/get/eviction/TTL tests
- `tests/errors/llm-rate-limiter.test.js` — rate limiter allow/block/reset tests

## Test plan

- [ ] Verify sync mode still works as before (no regressions)
- [ ] Test async mode: error returns 500 immediately, LLM result appears in console/log after
- [ ] Test rate limiting: trigger >10 errors/min and confirm LLM calls are capped
- [ ] Test caching: same error at same throw site reuses cached result
- [ ] Test `ammo.params` populated correctly for parameterized routes (e.g. `/:id`)
- [ ] Test 404 routes run global middlewares (CORS headers present on 404 responses)
- [ ] Run existing test suite (`npm test`)
